### PR TITLE
今すぐ実行メニューを追加

### DIFF
--- a/deadline-notification.js
+++ b/deadline-notification.js
@@ -38,9 +38,9 @@ function saveToken(str) {
 
 function executeNow() {
   var output = HtmlService.createHtmlOutputFromFile('prompt')
-      .setSandboxMode(HtmlService.SandboxMode.IFRAME)
-      .setWidth(400)
-      .setHeight(200);
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME)
+    .setWidth(400)
+    .setHeight(200);
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   ss.show(output);
 }
@@ -49,7 +49,7 @@ function executeNow() {
 function getProjectList() {
   var sheet = SpreadsheetApp.getActiveSheet();
   var values = sheet.getSheetValues(2, 1, sheet.getLastRow(), 1);
-  return values[0]
+  return values;
 }
 
 
@@ -63,25 +63,7 @@ function postSingleNotificationMessage(row) {
   var slackMessage = new SlackMessage();
   var sheet = SpreadsheetApp.getActiveSheet();
   var values = sheet.getSheetValues(row, 1, 1, sheet.getLastColumn());
-  var sheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
-
-  var title = values[0][COLUMN_TITLE];
-  var channel = values[0][COLUMN_CHANNEL];
-  var launchDate = values[0][COLUMN_LAUNCH_DATE];
-  var icon = values[0][COLUMN_ICON];
-
-  var message;
-  var prevDate = new Date();
-  prevDate.setDate(prevDate.getDate() - 1);
-  if (launchDate < prevDate) {
-    message = "このプロジェクトは終了しました！<" + sheetUrl + "|ここ>から削除してください";
-  } else {
-    var leftDays = Math.ceil((launchDate - now) / DAY_MSECONDS);
-    var leftWorkDays = countWorkday(leftDays, workdays);
-    message = (launchDate.getMonth() + 1) + "月" + launchDate.getDate() + "日まであと" + leftWorkDays + "営業日です";
-  }
-
-  slackMessage.postMessage(title, channel, message, icon);  
+  postNotificationMessage(slackMessage, workdays, values[0]);
 }
 
 
@@ -96,31 +78,14 @@ function postNotificationMessage() {
   var sheet = SpreadsheetApp.getActiveSheet();
   var values = sheet.getDataRange().getValues();
   var maxRow = sheet.getLastRow();
-  var sheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
   
   for (var r = 1; r < maxRow; r++) {
-    var title = values[r][COLUMN_TITLE];
-    var channel = values[r][COLUMN_CHANNEL];
-    var launchDate = values[r][COLUMN_LAUNCH_DATE];
-    var icon = values[r][COLUMN_ICON];
-    
-    var message;
-    var prevDate = new Date();
-    prevDate.setDate(prevDate.getDate() - 1);
-    if (launchDate < prevDate) {
-      message = "このプロジェクトは終了しました！<" + sheetUrl + "|ここ>から削除してください";
-    } else {
-      var leftDays = Math.ceil((launchDate - now) / DAY_MSECONDS);
-      var leftWorkDays = countWorkday(leftDays, workdays);
-      message = (launchDate.getMonth() + 1) + "月" + launchDate.getDate() + "日まであと" + leftWorkDays + "営業日です";
-    }
-  
-    slackMessage.postMessage(title, channel, message, icon);
+    postNotificationMessage(slackMessage, workdays, values[r]);
   }
 }
 
 
-function postNotificationMessage(slackMessage, workdays, values, now) {
+function postNotificationMessage(slackMessage, workdays, values) {
   var title = values[COLUMN_TITLE];
   var channel = values[COLUMN_CHANNEL];
   var launchDate = values[COLUMN_LAUNCH_DATE];

--- a/deadline-notification.js
+++ b/deadline-notification.js
@@ -10,7 +10,7 @@ function onOpen() {
   SpreadsheetApp.getUi()
     .createMenu("Slackの設定")
     .addItem("Slack API Tokenの登録", "setAPIToken")
-    .addItem("今すぐ実行", "executeNow")
+    .addItem("今すぐ実行", "showExecutePrompt")
     .addToUi();
 }
 
@@ -36,7 +36,7 @@ function saveToken(str) {
 }
 
 
-function executeNow() {
+function showExecutePrompt() {
   var output = HtmlService.createHtmlOutputFromFile('prompt')
     .setSandboxMode(HtmlService.SandboxMode.IFRAME)
     .setWidth(400)
@@ -54,116 +54,24 @@ function getProjectList() {
 
 
 function postSingleNotificationMessage(row) {
-  var now = new Date();
-  var workdays = loadWorkdays(now);
-  if (!workdays[0]) {
-    return;
-  }
-
-  var slackMessage = new SlackMessage();
+  var notification = new Notification();
   var sheet = SpreadsheetApp.getActiveSheet();
   var values = sheet.getSheetValues(row, 1, 1, sheet.getLastColumn());
-  postNotificationMessage(slackMessage, workdays, values[0]);
+  notification.postMessage(values[0]);
 }
 
 
 function postAllNotificationMessage() {
-  var now = new Date();
-  var workdays = loadWorkdays(now);
-  if (!workdays[0]) {
+  var notification = new Notification();
+  if (notification.isHoliday()) {
     return;
   }
-  
-  var slackMessage = new SlackMessage();
+
   var sheet = SpreadsheetApp.getActiveSheet();
   var values = sheet.getDataRange().getValues();
   var maxRow = sheet.getLastRow();
   
   for (var r = 1; r < maxRow; r++) {
-    postNotificationMessage(slackMessage, workdays, values[r]);
+    notification.postMessage(values[r]);
   }
 }
-
-
-function postNotificationMessage(slackMessage, workdays, values) {
-  var title = values[COLUMN_TITLE];
-  var channel = values[COLUMN_CHANNEL];
-  var launchDate = values[COLUMN_LAUNCH_DATE];
-  var icon = values[COLUMN_ICON];
-  
-  var message;
-  var now = new Date();
-  var prevDate = new Date();
-  prevDate.setDate(prevDate.getDate() - 1);
-  if (launchDate < prevDate) {
-    var sheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
-    message = "このプロジェクトは終了しました！<" + sheetUrl + "|ここ>から削除してください";
-  } else {
-    var leftDays = Math.ceil((launchDate - now) / DAY_MSECONDS);
-    var leftWorkDays = countWorkday(leftDays, workdays);
-    message = (launchDate.getMonth() + 1) + "月" + launchDate.getDate() + "日まであと" + leftWorkDays + "営業日です";
-  }
-
-  slackMessage.postMessage(title, channel, message, icon); 
-}
-
-
-function loadWorkdays() {
-  var workdays = [];
-  var calendar = CalendarApp.getCalendarById('ja.japanese#holiday@group.v.calendar.google.com');
-  var now = new Date();
-  var dateAfterYear = new Date();
-  dateAfterYear.setYear(dateAfterYear.getFullYear() + 1);
-  var holidays = calendar.getEvents(now, dateAfterYear).map(function(item) {
-    var holidayDate = item.getStartTime();
-    return holidayDate.getFullYear() + "/" + (holidayDate.getMonth() + 1) + "/" + holidayDate.getDate();
-  }); 
-  for (var i = 0; i < 365; i++) {
-    var weekday = now.getDay();
-    var formattedDate = now.getFullYear() + "/" + (now.getMonth() + 1) + "/" + now.getDate();
-    var isHoliday = holidays.indexOf(formattedDate) != -1;
-    workdays[i] = (weekday == SUNDAY || weekday == SATURDAY || isHoliday) ? 0 : 1;
-    now.setDate(now.getDate() + 1);
-  }
-  return workdays;
-}
-
-
-function countWorkday(days, workdays) {
-  if (days <= 0) {
-    return 0;
-  }
-  var targetWorkdays = workdays.slice(0, days);
-  var count = targetWorkdays.reduce(function(result, item, index, array) {
-    return result + (index < days ? item : 0); 
-  });
-  return count;
-}
-
-
-var SlackMessage = (function() {
-  function SlackMessage() {
-    var prop = PropertiesService.getScriptProperties().getProperties();
-    this.slackApp = SlackApp.create(prop.token);
-    this.channels = this.slackApp.channelsList().channels;
-  }
-  
-  SlackMessage.prototype.postMessage = function(title, channelName, message, icon) {
-    var channelId = this.getChannelId(channelName);
-    this.slackApp.postMessage(channelId,
-                              message, 
-                              {
-                                username : title,
-                                icon_emoji : ":" + icon + ":",
-                              });
-  };
-  
-  SlackMessage.prototype.getChannelId = function(channelName) {
-    var channel = this.channels.filter(function(item, index) {
-      return item.name === channelName;
-    });
-    return channel[0] ? channel[0].id : null;
-  };
-  
-  return SlackMessage;
-})();

--- a/deadline-notification.js
+++ b/deadline-notification.js
@@ -67,7 +67,7 @@ function postSingleNotificationMessage(row) {
 }
 
 
-function postNotificationMessage() {
+function postAllNotificationMessage() {
   var now = new Date();
   var workdays = loadWorkdays(now);
   if (!workdays[0]) {

--- a/notification.js
+++ b/notification.js
@@ -1,0 +1,66 @@
+var Notification = (function() {
+  function Notification() {
+    var now = Date();
+    this.workdays = this.loadWorkdays(now);
+    this.slackMessage = new SlackMessage();
+  }
+
+  Notification.prototype.postMessage = function(values) {
+    var title = values[COLUMN_TITLE];
+    var channel = values[COLUMN_CHANNEL];
+    var launchDate = values[COLUMN_LAUNCH_DATE];
+    var icon = values[COLUMN_ICON];
+    
+    var message;
+    var now = new Date();
+    var prevDate = new Date();
+    prevDate.setDate(prevDate.getDate() - 1);
+    if (launchDate < prevDate) {
+      var sheetUrl = SpreadsheetApp.getActiveSpreadsheet().getUrl();
+      message = "このプロジェクトは終了しました！<" + sheetUrl + "|ここ>から削除してください";
+    } else {
+      var leftDays = Math.ceil((launchDate - now) / DAY_MSECONDS);
+      var leftWorkDays = this.countWorkday(leftDays);
+      message = (launchDate.getMonth() + 1) + "月" + launchDate.getDate() + "日まであと" + leftWorkDays + "営業日です";
+    }
+
+    this.slackMessage.postMessage(title, channel, message, icon); 
+  };
+
+  Notification.prototype.loadWorkdays = function() {
+    var workdays = [];
+    var calendar = CalendarApp.getCalendarById('ja.japanese#holiday@group.v.calendar.google.com');
+    var now = new Date();
+    var dateAfterYear = new Date();
+    dateAfterYear.setYear(dateAfterYear.getFullYear() + 1);
+    var holidays = calendar.getEvents(now, dateAfterYear).map(function(item) {
+      var holidayDate = item.getStartTime();
+      return holidayDate.getFullYear() + "/" + (holidayDate.getMonth() + 1) + "/" + holidayDate.getDate();
+    }); 
+    for (var i = 0; i < 365; i++) {
+      var weekday = now.getDay();
+      var formattedDate = now.getFullYear() + "/" + (now.getMonth() + 1) + "/" + now.getDate();
+      var isHoliday = holidays.indexOf(formattedDate) != -1;
+      workdays[i] = (weekday == SUNDAY || weekday == SATURDAY || isHoliday) ? 0 : 1;
+      now.setDate(now.getDate() + 1);
+    }
+    return workdays;
+  };
+
+  Notification.prototype.countWorkday = function(days) {
+    if (days <= 0) {
+      return 0;
+    }
+    var targetWorkdays = this.workdays.slice(0, days);
+    var count = targetWorkdays.reduce(function(result, item, index, array) {
+      return result + (index < days ? item : 0); 
+    });
+    return count;   
+  };
+
+  Notification.prototype.isHoliday = function() {
+    return !this.workdays[0];
+  };
+
+  return Notification;
+})();

--- a/prompt.html
+++ b/prompt.html
@@ -21,12 +21,10 @@
 
 <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons.css">
 <style>
-  h1 {font-size:12pt; padding:5px;}
-  p {margin:10px;}
+  h1 {font-size: 12pt; padding: 5px;}
+  p {margin: 10px;}
+  .send-button {margin-top: 10px;}
 </style>
- 
-<div id="list"></div>
-<div id="list2"></div>
 
 <h1>実行する案件を選択してください</h1>
 <form name="projectForm">
@@ -34,7 +32,7 @@
 	</select>
 </form>
 
-<div style="padding-top:10px;">
+<div class="send-button">
 	<input type="button" class="action" value="実行" onclick="sendMessage()" />
 </div>
 

--- a/prompt.html
+++ b/prompt.html
@@ -1,0 +1,41 @@
+<script type="text/javascript">
+	function successHandler() {
+		google.script.host.close();
+	}
+
+	function loadProjectList(projects) {
+		var projectSelect = document.forms.projectForm.project;
+		for (var i = 0; i < projects.length - 1; i++) {
+			projectSelect.options[i] = new Option(projects[i]);
+		}
+	}
+
+	function sendMessage() {
+		document.getElementById("loading").innerHTML = "Loading...";
+		var projectNumber = document.forms.projectForm.project.selectedIndex + 2;
+		google.script.run.withSuccessHandler(successHandler).postSingleNotificationMessage(projectNumber);
+	}
+
+	google.script.run.withSuccessHandler(loadProjectList).getProjectList();
+</script>
+
+<link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons.css">
+<style>
+  h1 {font-size:12pt; padding:5px;}
+  p {margin:10px;}
+</style>
+ 
+<div id="list"></div>
+<div id="list2"></div>
+
+<h1>実行する案件を選択してください</h1>
+<form name="projectForm">
+	<select name="project">
+	</select>
+</form>
+
+<div style="padding-top:10px;">
+	<input type="button" class="action" value="実行" onclick="sendMessage()" />
+</div>
+
+<div id="loading"></div>

--- a/slackMessage.js
+++ b/slackMessage.js
@@ -1,0 +1,26 @@
+var SlackMessage = (function() {
+  function SlackMessage() {
+    var prop = PropertiesService.getScriptProperties().getProperties();
+    this.slackApp = SlackApp.create(prop.token);
+    this.channels = this.slackApp.channelsList().channels;
+  }
+  
+  SlackMessage.prototype.postMessage = function(title, channelName, message, icon) {
+    var channelId = this.getChannelId(channelName);
+    this.slackApp.postMessage(channelId,
+                              message, 
+                              {
+                                username : title,
+                                icon_emoji : ":" + icon + ":",
+                              });
+  };
+  
+  SlackMessage.prototype.getChannelId = function(channelName) {
+    var channel = this.channels.filter(function(item, index) {
+      return item.name === channelName;
+    });
+    return channel[0] ? channel[0].id : null;
+  };
+  
+  return SlackMessage;
+})();


### PR DESCRIPTION
## 概要

スプレッドシートのメニューに「今すぐ実行」のメニューを追加しました。これで、チャンネル毎に今すぐ実行してテストをすることができるようになりました。
## 実装

プロンプトの画面にはHTMLを使いました。開いたときにJavascriptでスプレッドシートを読み込むAPIを実行して、セレクトボックスに案件一覧を表示させます。また、実行を押したあとも同様にJavascriptでポストするAPIを叩くようになっています。　
- `postSingleNotificationMessage` : 特定のチャンネルだけにポストします
- `postAllNotificationMessage` : すべてのチャンネルにポストします
## なんか

HTMLファイルのインデントがおかしいことになってます。原因は謎です。
